### PR TITLE
read file without storing sheets in memory

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -82,6 +82,8 @@ open a workbook.
 			* The caller may save memory by calling workbook.sheet.unload() when finished with the sheet. This applies irrespective of the state of onDemand.  
 			* workbook.sheet.loaded() checks whether a sheet is loaded or not.  
 			* workbook.cleanUp() should be called at end of node-xlrd.open() callback.  
+		* streamRead : function(obj)
+			allows reading the file without storing it in memory, sending each row to provided callback function as soon as it was read
 	* callback : function(err, workbook)
     
 ###	node-xlrd.common

--- a/lib/compDoc.js
+++ b/lib/compDoc.js
@@ -63,7 +63,7 @@ function likeBuffer(fd, size){
 			if(end && end > len) throw new Error('likeBuffer Error : end %d of toInt32LEs beyond buffer length %d', end, len);		
 			
 			var length = end - start;
-			var ret = new Buffer(length);
+			var ret = Buffer.alloc(length);
 			buf.copy(ret,0,_start + start, _start + end);
 			return  ret;
 		}
@@ -76,11 +76,11 @@ function likeBuffer(fd, size){
 	
 	function FileBuffer(fd, defaultBufferSize){
 		var self = this;
-		var buf = new Buffer(defaultBufferSize);
+		var buf = Buffer.alloc(defaultBufferSize);
 		var len = 0;
 		
 		//access directly 
-		var b4 = new Buffer(4);
+		var b4 = Buffer.alloc(4);
 		self.readUInt8 = function(position){
 			fs.readSync(fd,b4,0,1,position);
 			return b4.getUInt8(0);
@@ -103,7 +103,7 @@ function likeBuffer(fd, size){
 
 		self.slice = function(start, end){
 			var length = end - start;
-			var buf = new Buffer(length);
+			var buf = Buffer.alloc(length);
 			if(length) fs.readSync(fd,buf,0,length,start);
 			return buf;
 		}
@@ -121,7 +121,7 @@ function likeBuffer(fd, size){
 		//use buffer
 		self.pull = function(start,end){
 			len = end -start;
-			if(buf.length < len) buf = Buffer.concat([buf,new Buffer(len-buf.length)] ,len);
+			if(buf.length < len) buf = Buffer.concat([buf,Buffer.alloc(len-buf.length)] ,len);
 			return fs.readSync(fd,buf,0,len,start);
 		}
 		self.getUInt8= function(position){
@@ -165,12 +165,12 @@ function likeBuffer(fd, size){
 			if(end && end > len) throw new Error('FileBuffer Error : end %d of toInt32LEs beyond buffer length %d', end, len);		
 			
 			var length = end - start;
-			var ret = new Buffer(length);
+			var ret = Buffer.alloc(length);
 			buf.copy(ret,0,start,end);
 			return  ret;
 			/*
 			var length = end - start;
-			var ret = new Buffer(length);
+			var ret = Buffer.alloc(length);
 			fs.readSync(fd,ret,0,length,_start+start);
 			return ret;
 			*/
@@ -414,7 +414,7 @@ exports.CompDoc = function (fd, totalSize){
 	var sscsDir = dirList[0];
 	assert(sscsDir.etype == 5 ,'sscsDir.etype == 5 '); // root entry
 	if(sscsDir.firstSID < 0 || sscsDir.totalSize == 0){
-		self.SSCS = new Buffer(0);
+		self.SSCS = Buffer.alloc(0);
 	}else{
 		self.SSCS = getStream(self,wbuf,512, sat, secSize, sscsDir.firstSID,sscsDir.totalSize, "SSCS", 4);
 	}

--- a/lib/node-xlrd.js
+++ b/lib/node-xlrd.js
@@ -8,7 +8,7 @@ var fs = require('fs'),
 //open(fileName, function(err, workbook))
 exports.open = function(fileName, options, callback){
 	var peekSz = 4;
-	var buf = new Buffer(4);
+	var buf = Buffer.alloc(4);
 	fs.open(fileName, 'r',function(err,fd){
 		if(typeof options == 'function'){
 			callback = options;

--- a/lib/sheet.js
+++ b/lib/sheet.js
@@ -45,7 +45,7 @@ var _WINDOW2_options = {
 // was returned when you called xlrd.open_workbook("myfile.xls"). 
 
 
-module.exports = function Sheet(book, position, name, index){
+module.exports = function Sheet(book, position, name, index, streamRead){
 	var self = this;
     ////
     // Name of sheet.
@@ -283,6 +283,9 @@ module.exports = function Sheet(book, position, name, index){
 	var _cellValues = [];
 	var _cellTypes = [];
 	var _cellXFIndexes = [];
+    self.streamRead = streamRead;
+    var _prevRowNumber = -1;
+    var _currentRowObj = {};
 	self.defaultColWidth = null;
 	self.standardWidth = null;
 	self.defaultRowHeight = null;
@@ -416,6 +419,21 @@ module.exports = function Sheet(book, position, name, index){
             // we have a number, so look up the cell type
             ctype = self._xf_index_to_xl_type_map[xfIndex];
 		}
+        if (typeof streamRead === 'function') {
+            if (_prevRowNumber != rowx) {
+                if (_prevRowNumber > (-1)) {
+                    streamRead(_currentRowObj);
+                    _currentRowObj = {};
+                }
+                _prevRowNumber = rowx;
+            }
+            _currentRowObj[colx] = (
+                ctype === comm.XL_CELL_DATE ?
+                    toDate(value, book.dateMode) :
+                    value
+            );
+            return;
+        }
         assert(0 <= colx && colx < self.utterMaxCols,'0 <= colx < self.utterMaxCols');
         assert(0 <= rowx && rowx < self.utterMaxRows,'0 <= rowx < self.utterMaxRows');
         var fmtInf = self.formattingInfo;
@@ -523,6 +541,21 @@ module.exports = function Sheet(book, position, name, index){
 		if(!ctype)
             // we have a number, so look up the cell type
             ctype = self._xf_index_to_xl_type_map[xfIndex];
+        if (typeof streamRead === 'function') {
+            if (_prevRowNumber != rowx) {
+                if (_prevRowNumber > (-1)) {
+                    streamRead(_currentRowObj);
+                    _currentRowObj = {};
+                }
+                _prevRowNumber = rowx;
+            }
+            _currentRowObj[colx] = (
+                ctype === comm.XL_CELL_DATE ?
+                    toDate(value, book.dateMode) :
+                    value
+            );
+            return;
+        }
         // assert 0 <= colx < self.utterMaxCols
         // assert 0 <= rowx < self.utterMaxRows
 		if(_cellTypes[rowx] === undefined || _cellTypes[rowx][colx] === undefined ){
@@ -1492,6 +1525,9 @@ module.exports = function Sheet(book, position, name, index){
                 // if DEBUG: print "SHEET.READ: Unhandled record type %02x %d bytes %r" % (rc, dataLen, data)
                 ;
 		}
+        if ( (typeof streamRead === 'function') && (_prevRowNumber > (-1)) ) {
+            streamRead(_currentRowObj);
+        }
         if (!eofFound)
             throw new Error(util.format("Sheet %d (%r) missing EOF record",self.index, self.name));
         tidyDimensions();

--- a/lib/sheet.js
+++ b/lib/sheet.js
@@ -1560,7 +1560,7 @@ function unpackRK(data, start, end){
         return i*1.0;
     }else{
         // It's the most significant 30 bits of an IEEE 754 64-bit FP number
-		var buf = new Buffer([0,0,0,0,flags & 252,data[start+1],data[start+2],data[start+3]] );
+		var buf = Buffer.from([0,0,0,0,flags & 252,data[start+1],data[start+2],data[start+3]] );
         var d = buf.readDoubleLE(0);
         if (flags & 1)
             return d / 100.0;

--- a/lib/workbook.js
+++ b/lib/workbook.js
@@ -19,6 +19,7 @@ exports.openWorkbook = function(fd, options, callback){
 	var opts = options || {};//todo: default 값으로 병합
 	var interObj = {}
 	var bk = new Workbook(interObj);
+    bk.streamRead = opts.streamRead;
 
 	interObj.loadBiffN(fd);
 	
@@ -496,7 +497,7 @@ function Workbook(interObj){
 		// Confirmed by Daniel Rentz: happens when Excel does "save as"
 		// creating an old version file; ignore version details on sheet BOF.
 		
-		var sh = new Sheet(self, self._position,_sheetNames[sheetIndex],sheetIndex);
+		var sh = new Sheet(self, self._position,_sheetNames[sheetIndex],sheetIndex,self.streamRead);
 		sh.read(self);
 		_sheetList[sheetIndex] = sh;
 		return sh;

--- a/lib/workbook.js
+++ b/lib/workbook.js
@@ -303,7 +303,7 @@ function Workbook(interObj){
 		self.streamLength = stats.size;
 		_fd = fd;
 		self.base = 0;
-		var buf = new Buffer(8);
+		var buf = Buffer.alloc(8);
 		fs.readSync(fd,buf,0,8,0);
 		var bsig =buf.toString('hex').toLowerCase();
 		
@@ -461,7 +461,7 @@ function Workbook(interObj){
 	//return Buffer;
 	function read(pos, length){
 		/*
-		var buf = new Buffer(length);
+		var buf = Buffer.alloc(length);
 		var len = fs.readSync(_fd,buf,0,length,pos);
 		self._position = pos + len;
 		return length == len ? buf : buf.slice(0,len);
@@ -591,7 +591,7 @@ function Workbook(interObj){
 		if( opcode == _EOF)
 			bofError('Expected BOF record; met end of file');
 		if(comm.bofCodes.indexOf(opcode)<0){
-			var buf = new Buffer(8);
+			var buf = Buffer.alloc(8);
 			fs.readSync(_fd,buf,0,8,savPos);
 			bofError('Expected BOF record; found %r', buf.toString('hex') );
 		}
@@ -599,11 +599,11 @@ function Workbook(interObj){
 		if( length == _EOF)
 			bofError('Incomplete BOF record[1]; met end of file')
 		if( ! (4 <= length &&  length <= 20)){
-			var opcd = new Buffer(4);
+			var opcd = Buffer.alloc(4);
 			opcd.writeUInt32LE(opcode,0);
 			bofError(util.format('Invalid length (%d) for BOF record type 0x%s', length, opcd.toString('hex')));
 		}
-		var padding = new Buffer(Math.max(0, comm.bofLen[opcode] - length));
+		var padding = Buffer.alloc(Math.max(0, comm.bofLen[opcode] - length));
 		padding.fill(0);
 		var data = read(self._position, length);//Type Buffer
 		//if DEBUG: fprintf(self.logfile, "\ngetbof(): data=%r\n", data);


### PR DESCRIPTION
I needed a possibility to read and process **very** large files without storing them in memory (stream reading rows of data). The proposed changes provide this possibility using callback function. Could you review them and if possible merge and update the npm?
Thank you.