### PR TITLE
fixed a deprecation warning

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,6 +10,10 @@ node.js's module to extract data from Microsoft Excel™ File(.xls)
 *  only cell data without a formula, format, hyperlink.
 
 ## Changelog
+### 0.3.0
+* fixed a deprecation warning
+	'new Buffer(size)' or 'new Buffer(array)' emits a deprecation warning.
+	
 ### 0.2.5
 * fixed bugs
 	crash when opening an EXCEL file contained hyperlink, text box, form control, note, table.

--- a/lib/compDoc.js
+++ b/lib/compDoc.js
@@ -63,7 +63,7 @@ function likeBuffer(fd, size){
 			if(end && end > len) throw new Error('likeBuffer Error : end %d of toInt32LEs beyond buffer length %d', end, len);		
 			
 			var length = end - start;
-			var ret = new Buffer(length);
+			var ret = Buffer.alloc(length);
 			buf.copy(ret,0,_start + start, _start + end);
 			return  ret;
 		}
@@ -76,11 +76,11 @@ function likeBuffer(fd, size){
 	
 	function FileBuffer(fd, defaultBufferSize){
 		var self = this;
-		var buf = new Buffer(defaultBufferSize);
+		var buf = Buffer.alloc(defaultBufferSize);
 		var len = 0;
 		
 		//access directly 
-		var b4 = new Buffer(4);
+		var b4 = Buffer.alloc(4);
 		self.readUInt8 = function(position){
 			fs.readSync(fd,b4,0,1,position);
 			return b4.getUInt8(0);
@@ -103,7 +103,7 @@ function likeBuffer(fd, size){
 
 		self.slice = function(start, end){
 			var length = end - start;
-			var buf = new Buffer(length);
+			var buf = Buffer.alloc(length);
 			if(length) fs.readSync(fd,buf,0,length,start);
 			return buf;
 		}
@@ -121,7 +121,7 @@ function likeBuffer(fd, size){
 		//use buffer
 		self.pull = function(start,end){
 			len = end -start;
-			if(buf.length < len) buf = Buffer.concat([buf,new Buffer(len-buf.length)] ,len);
+			if(buf.length < len) buf = Buffer.concat([buf,Buffer.alloc(len-buf.length)] ,len);
 			return fs.readSync(fd,buf,0,len,start);
 		}
 		self.getUInt8= function(position){
@@ -165,7 +165,7 @@ function likeBuffer(fd, size){
 			if(end && end > len) throw new Error('FileBuffer Error : end %d of toInt32LEs beyond buffer length %d', end, len);		
 			
 			var length = end - start;
-			var ret = new Buffer(length);
+			var ret = Buffer.alloc(length);
 			buf.copy(ret,0,start,end);
 			return  ret;
 			/*
@@ -414,7 +414,7 @@ exports.CompDoc = function (fd, totalSize){
 	var sscsDir = dirList[0];
 	assert(sscsDir.etype == 5 ,'sscsDir.etype == 5 '); // root entry
 	if(sscsDir.firstSID < 0 || sscsDir.totalSize == 0){
-		self.SSCS = new Buffer(0);
+		self.SSCS = Buffer.alloc(0);
 	}else{
 		self.SSCS = getStream(self,wbuf,512, sat, secSize, sscsDir.firstSID,sscsDir.totalSize, "SSCS", 4);
 	}

--- a/lib/node-xlrd.js
+++ b/lib/node-xlrd.js
@@ -5,10 +5,20 @@ var fs = require('fs'),
 	comm = require('./common'),
 	assert = require('assert');
 
+if( Buffer.prototype.alloc === undefined){
+	Buffer.prototype.alloc = function(size){
+		return new Buffer(size);
+	}
+}
+if( Buffer.prototype.from === undefined){
+	Buffer.prototype.from = function(array){
+		return new Buffer(array);
+	}
+}
 //open(fileName, function(err, workbook))
 exports.open = function(fileName, options, callback){
 	var peekSz = 4;
-	var buf = new Buffer(4);
+	var buf = Buffer.alloc(4);
 	fs.open(fileName, 'r',function(err,fd){
 		if(typeof options == 'function'){
 			callback = options;

--- a/lib/sheet.js
+++ b/lib/sheet.js
@@ -1567,7 +1567,7 @@ function unpackRK(data, start, end){
         return i*1.0;
     }else{
         // It's the most significant 30 bits of an IEEE 754 64-bit FP number
-		var buf = new Buffer([0,0,0,0,flags & 252,data[start+1],data[start+2],data[start+3]] );
+		var buf = Buffer.from([0,0,0,0,flags & 252,data[start+1],data[start+2],data[start+3]] );
         var d = buf.readDoubleLE(0);
         if (flags & 1)
             return d / 100.0;

--- a/lib/workbook.js
+++ b/lib/workbook.js
@@ -303,7 +303,7 @@ function Workbook(interObj){
 		self.streamLength = stats.size;
 		_fd = fd;
 		self.base = 0;
-		var buf = new Buffer(8);
+		var buf = Buffer.alloc(8);
 		fs.readSync(fd,buf,0,8,0);
 		var bsig =buf.toString('hex').toLowerCase();
 		
@@ -591,7 +591,7 @@ function Workbook(interObj){
 		if( opcode == _EOF)
 			bofError('Expected BOF record; met end of file');
 		if(comm.bofCodes.indexOf(opcode)<0){
-			var buf = new Buffer(8);
+			var buf = Buffer.alloc(8);
 			fs.readSync(_fd,buf,0,8,savPos);
 			bofError('Expected BOF record; found %r', buf.toString('hex') );
 		}
@@ -599,11 +599,11 @@ function Workbook(interObj){
 		if( length == _EOF)
 			bofError('Incomplete BOF record[1]; met end of file')
 		if( ! (4 <= length &&  length <= 20)){
-			var opcd = new Buffer(4);
+			var opcd = Buffer.alloc(4);
 			opcd.writeUInt32LE(opcode,0);
 			bofError(util.format('Invalid length (%d) for BOF record type 0x%s', length, opcd.toString('hex')));
 		}
-		var padding = new Buffer(Math.max(0, comm.bofLen[opcode] - length));
+		var padding = Buffer.alloc(Math.max(0, comm.bofLen[opcode] - length));
 		padding.fill(0);
 		var data = read(self._position, length);//Type Buffer
 		//if DEBUG: fprintf(self.logfile, "\ngetbof(): data=%r\n", data);


### PR DESCRIPTION
constructing Buffers via Buffer() without using new emits a deprecation warning in certain versions of node.js
my pull request resovle the problem.