### PR TITLE
fixed a deprecation warning and a bug

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -10,20 +10,24 @@ node.js's module to extract data from Microsoft Excel™ File(.xls)
 *  only cell data without a formula, format, hyperlink.
 
 ## Changelog
+### 0.3.3
+* fixed a deprecation warning
+	* Calling an asynchronous function without callback is deprecated.
 ### 0.3.2
 * fixed util.format() method format specifier error.
 * code formatting with Prettier.
+
 ### 0.3.0
 * fixed a deprecation warning
 	'new Buffer(size)' or 'new Buffer(array)' emits a deprecation warning.
 	
 ### 0.2.5
 * fixed bugs
-	crash when opening an EXCEL file contained hyperlink, text box, form control, note, table.
+	* crash when opening an EXCEL file contained hyperlink, text box, form control, note, table.
 
 ### 0.2.4
 * used lowerCamelCase for inner variables, properties and function names.  
-    moved to javascript naming conventions from python.
+    * moved to javascript naming conventions from python.
 * added 'toCountryName' function
 * added 'lastUser' property
 * fixed bugs
@@ -34,7 +38,7 @@ node.js's module to extract data from Microsoft Excel™ File(.xls)
 ### 0.2.1  
 * added 'onDemand' option
 * add api
-	workbook.cleanUp()
+	* workbook.cleanUp()
 * fixed bugs
 
 ### 0.2.0

--- a/lib/node-xlrd.js
+++ b/lib/node-xlrd.js
@@ -5,13 +5,13 @@ var fs = require('fs'),
   comm = require('./common'),
   assert = require('assert');
 
-if (Buffer.prototype.alloc === undefined) {
-  Buffer.prototype.alloc = function (size) {
+if (Buffer.alloc === undefined) {
+  Buffer.alloc = function (size) {
     return new Buffer(size);
   };
 }
-if (Buffer.prototype.from === undefined) {
-  Buffer.prototype.from = function (array) {
+if (Buffer.from === undefined) {
+  Buffer.from = function (array) {
     return new Buffer(array);
   };
 }
@@ -58,7 +58,7 @@ exports.open = function (fileName, options, callback) {
           if (cleanUpCount) return;
           cleanUpCount++;
           cleanUp();
-          fs.close(fd);
+          fs.close(fd, function (err) {});
         };
         try {
           callback(null, bk);

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-xlrd",
-  "version": "0.2.5",
+  "version": "0.3.3",
   "description": "node.js's module to extract data from Microsoft Excel™ File(.xls)",
   "main": "./lib/node-xlrd.js",
   "directories": {


### PR DESCRIPTION
- Calling an asynchronous function without callback is deprecated.
fixed a bug
- node.js v0.10.x, Buffer.alloc call undefined