### PR TITLE
update v0.3.6 ~ v0.3.8

### DIFF
--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,9 @@ node.js's module to extract data from Microsoft Excel™ File(.xls)
 *  from v13 to future versions : maybe
 
 ## Changelog
+### 0.3.5
+* fixed a error handling BOUNDSHEET.
+
 ### 0.3.4
 * rename './test'  to './examples'.
 * fixed example error.

--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,11 @@ node.js's module to extract data from Microsoft Excel™ File(.xls)
 *  from v13 to future versions : maybe
 
 ## Changelog
+### 0.3.6
+* fixed XL_ARRAY parsing error.
+* fixed fuction deriveEncoding() call missing.
+* fixed missing 'use strict' in common.js.
+
 ### 0.3.5
 * fixed a error handling BOUNDSHEET.
 

--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,9 @@ node.js's module to extract data from Microsoft Excel™ File(.xls)
 *  from v13 to future versions : maybe
 
 ## Changelog
+### 0.3.7
+* fixed deriveEncoding() call error.
+
 ### 0.3.6
 * fixed XL_ARRAY parsing error.
 * fixed fuction deriveEncoding() call missing.

--- a/Readme.md
+++ b/Readme.md
@@ -14,6 +14,11 @@ node.js's module to extract data from Microsoft Excel™ File(.xls)
 *  from v13 to future versions : maybe
 
 ## Changelog
+### 0.3.8
+* updated update iconv-lite version
+	* v0.2.11 to v0.6.2
+* fixed iconv-lite supported encoding names
+
 ### 0.3.7
 * fixed deriveEncoding() call error.
 
@@ -250,36 +255,50 @@ Nominal number of columns in sheet. It is 1 + the maximum column index found, ig
 ```js
 var xl = require('node-xlrd');
 
-xl.open('./test.xls', function(err,bk){
-	if(err) {console.log(err.name, err.message); return;}
-	
-	var shtCount = bk.sheet.count;
-	for(var sIdx = 0; sIdx < shtCount; sIdx++ ){
-		console.log('sheet "%d" ', sIdx);
-		console.log('  check loaded : %s', bk.sheet.loaded(sIdx) );
-		var sht = bk.sheets[sIdx],
-			rCount = sht.row.count,
-			cCount = sht.column.count;
-		console.log('  name = %s; index = %d; rowCount = %d; columnCount = %d', sht.name, sIdx, rCount, cCount);
-		for(var rIdx = 0; rIdx < rCount; rIdx++){
-			for(var cIdx = 0; cIdx < cCount; cIdx++){
-				try{
-					console.log('  cell : row = %d, col = %d, value = "%s"', rIdx, cIdx, sht.cell(rIdx,cIdx));
-				}catch(e){
-					console.log(e.message);
-				}
-			}
-		}
-		
-		//save memory
-		//console.log('  try unloading : index %d', sIdx );
-		//if(bk.sheet.loaded(sIdx))
-		//	bk.sheet.unload(sIdx);
-		//console.log('  check loaded : %s', bk.sheet.loaded(sIdx) );
-	}
-	// if onDemand == false, allow function 'workbook.cleanUp()' to be omitted,
-	// because it is called by caller 'node-xlrd.open()' after callback finished.
-	//bk.cleanUp();
+xl.open('./test.xls', function (err, bk) {
+  if (err) {
+    console.log(err.name, err.message);
+    return;
+  }
+
+  var shtCount = bk.sheet.count;
+  for (var sIdx = 0; sIdx < shtCount; sIdx++) {
+    console.log('sheet "%d" ', sIdx);
+    console.log('  check loaded : %s', bk.sheet.loaded(sIdx));
+    var sht = bk.sheets[sIdx],
+      rCount = sht.row.count,
+      cCount = sht.column.count;
+    console.log(
+      '  name = %s; index = %d; rowCount = %d; columnCount = %d',
+      sht.name,
+      sIdx,
+      rCount,
+      cCount
+    );
+    for (var rIdx = 0; rIdx < rCount; rIdx++) {
+      for (var cIdx = 0; cIdx < cCount; cIdx++) {
+        try {
+          console.log(
+            '  cell : row = %d, col = %d, value = "%s"',
+            rIdx,
+            cIdx,
+            sht.cell(rIdx, cIdx)
+          );
+        } catch (e) {
+          console.log(e.message);
+        }
+      }
+    }
+
+    //save memory
+    //console.log('  try unloading : index %d', sIdx );
+    //if(bk.sheet.loaded(sIdx))
+    //	bk.sheet.unload(sIdx);
+    //console.log('  check loaded : %s', bk.sheet.loaded(sIdx) );
+  }
+  // if onDemand == false, allow function 'workbook.cleanUp()' to be omitted,
+  // because it is called by caller 'node-xlrd.open()' after callback finished.
+  //bk.cleanUp();
 });
 ```
 ## License

--- a/lib/common.js
+++ b/lib/common.js
@@ -1,3 +1,5 @@
+'use strict';
+
 var iconv = require('iconv-lite');
 // unknown, date, number, general, text
 var format = (exports.Format = {FUN: 0, FDT: 1, FNU: 2, FGE: 3, FTX: 4});
@@ -198,12 +200,12 @@ exports.function upkbitsL(tgt_obj, src, manifest, local_setattr=setattr, local_i
 }
 */
 
-exports.decode = decode = function (data, pos, len, encoding) {
+var decode = (exports.decode = function (data, pos, len, encoding) {
   if (Buffer.isEncoding(encoding))
     return data.toString(encoding, pos, pos + len);
   var buf = pos == 0 && data.length == len ? data : data.slice(pos, pos + len);
   return iconv.decode(buf, encoding);
-};
+});
 
 //unpackString
 exports.unpackString = function (data, pos, encoding, lenRecordLength) {
@@ -238,7 +240,8 @@ exports.unpackStringUpdatePos = function (
 };
 exports.unpackUnicode = function (data, pos, lenRecordLength) {
   lenRecordLength = lenRecordLength || 2;
-  nchars = lenRecordLength == 1 ? data.readUInt8(pos) : data.readUInt16LE(pos);
+  var nchars =
+    lenRecordLength == 1 ? data.readUInt8(pos) : data.readUInt16LE(pos);
   var str = null;
   if (!nchars)
     // Ambiguous whether 0-length string should have an "options" byte.

--- a/lib/common.js
+++ b/lib/common.js
@@ -606,15 +606,17 @@ exports.function biff_count_records(mem, stream_offset, streamLen, fout=sys.stdo
         print("%8d %s" % (count, recname), file=fout)
 }
 */
+//iconv-lite supported encodings
+// -  https://github.com/ashtuchkin/iconv-lite/wiki/Supported-Encodings
 exports.encodingFromCodePage = {
   1200: 'utf16le',
-  10000: 'mac_roman',
-  10006: 'mac_greek', // guess
-  10007: 'mac_cyrillic', // guess
-  10029: 'mac_latin2', // guess
-  10079: 'mac_iceland', // guess
-  10081: 'mac_turkish', // guess
-  32768: 'mac_roman',
+  10000: 'macroman',
+  10006: 'macgreek', // guess
+  10007: 'maccyrillic', // guess
+  10029: 'maccenteuro', // guess
+  10079: 'maciceland', // guess
+  10081: 'macturkish', // guess
+  32768: 'macroman',
   32769: 'cp1252',
 };
 /*

--- a/lib/sheet.js
+++ b/lib/sheet.js
@@ -1183,9 +1183,9 @@ module.exports = function Sheet(book, position, name, index) {
       } else if (rc == comm.XL_ARRAY) {
         var row1x = data.readUInt16LE(0),
           rownx = data.readUInt16LE(2),
-          col1x = data.readUInt8(3),
-          colnx = data.readUInt8(4),
-          arrayFlags = data.readUInt8(5),
+          col1x = data.readUInt8(4),
+          colnx = data.readUInt8(5),
+          arrayFlags = data.readUInt8(6),
           tokslen = data.readUInt16LE(12);
 
         if (blahFormulas)

--- a/lib/workbook.js
+++ b/lib/workbook.js
@@ -588,7 +588,7 @@ function Workbook(interObj) {
     } else {
       var offset = data.readInt32LE(0),
         visibility = data.readUInt8(4),
-        sheetType = data.readUInt8(4);
+        sheetType = data.readUInt8(5);//read 6 bytes
       absPos = offset + self.base; // because global BOF is always at posn 0 in the stream
       if (bv < comm.BIFF_FIRST_UNICODE)
         sheetName = comm.unpackString(data, 6, self.encoding, 1);

--- a/lib/workbook.js
+++ b/lib/workbook.js
@@ -462,7 +462,7 @@ function Workbook(interObj) {
           self.xfEpilogue();
           //workbook.names_epilogue();
           //workbook.palette_epilogue();
-          if (!self.encoding); //workbook.deriveEncoding();
+          if (!self.encoding) bk.deriveEncoding();
           if (self.biffVersion == 45)
             // DEBUG = 0
             //if( DEBUG) print("global EOF: position", self._position, file=self.logfile);
@@ -588,7 +588,7 @@ function Workbook(interObj) {
     } else {
       var offset = data.readInt32LE(0),
         visibility = data.readUInt8(4),
-        sheetType = data.readUInt8(5);//read 6 bytes
+        sheetType = data.readUInt8(5); //read 6 bytes
       absPos = offset + self.base; // because global BOF is always at posn 0 in the stream
       if (bv < comm.BIFF_FIRST_UNICODE)
         sheetName = comm.unpackString(data, 6, self.encoding, 1);

--- a/lib/workbook.js
+++ b/lib/workbook.js
@@ -462,7 +462,7 @@ function Workbook(interObj) {
           self.xfEpilogue();
           //workbook.names_epilogue();
           //workbook.palette_epilogue();
-          if (!self.encoding) bk.deriveEncoding();
+          if (!self.encoding) deriveEncoding();
           if (self.biffVersion == 45)
             // DEBUG = 0
             //if( DEBUG) print("global EOF: position", self._position, file=self.logfile);

--- a/package.json
+++ b/package.json
@@ -1,10 +1,11 @@
 {
   "name": "node-xlrd",
-  "version": "0.3.7",
+  "version": "0.3.8",
   "description": "node.js's module to extract data from Microsoft Excel™ File(.xls)",
   "main": "./lib/node-xlrd.js",
   "directories": {
-    "examples": "examples"
+    "examples": "examples",
+    "docs": "documents"
   },
   "dependencies": {
     "iconv-lite": "~0.6.2"

--- a/package.json
+++ b/package.json
@@ -7,7 +7,7 @@
     "examples": "examples"
   },
   "dependencies": {
-    "iconv-lite": "~0.2.11"
+    "iconv-lite": "~0.6.2"
   },
   "devDependencies": {},
   "scripts": {

--- a/package.json
+++ b/package.json
@@ -1,10 +1,10 @@
 {
   "name": "node-xlrd",
-  "version": "0.3.5",
+  "version": "0.3.6",
   "description": "node.js's module to extract data from Microsoft Excel™ File(.xls)",
   "main": "./lib/node-xlrd.js",
   "directories": {
-    "test": "test"
+    "examples": "examples"
   },
   "dependencies": {
     "iconv-lite": "~0.2.11"

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-xlrd",
-  "version": "0.3.6",
+  "version": "0.3.7",
   "description": "node.js's module to extract data from Microsoft Excel™ File(.xls)",
   "main": "./lib/node-xlrd.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "node-xlrd",
-  "version": "0.3.4",
+  "version": "0.3.5",
   "description": "node.js's module to extract data from Microsoft Excel™ File(.xls)",
   "main": "./lib/node-xlrd.js",
   "directories": {


### PR DESCRIPTION
- update new version info - v0.3.6
  - fixed a error handling BOUNDSHEET
  - fixed XL_ARRAY parsing error
  - fixed deriveEncoding() call error
  - fixed missing 'use strict' in common.js
- update new version info - v0.3.7
  - fixed fuction deriveEncoding() call missing
- update new version info - v0.3.8
  - updated update iconv-lite version
	- v0.2.11 to v0.6.2
  - fixed iconv-lite supported encoding names

